### PR TITLE
Set armor to zero on revive

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -589,6 +589,7 @@ RegisterNetEvent('hospital:client:Revive', function()
     TriggerServerEvent('hud:server:RelieveStress', 100)
     TriggerServerEvent("hospital:server:SetDeathStatus", false)
     TriggerServerEvent("hospital:server:SetLaststandStatus", false)
+    TriggerServerEvent("hospital:server:SetArmor", 0)
     emsNotified = false
     QBCore.Functions.Notify(Lang:t('info.healthy'))
 end)


### PR DESCRIPTION
This should reset armor to 0 when a player is revived incase there are any discrepancies since the last sync to the database. As a player is downed, their armor should be removed at that point. This should guarantee that.